### PR TITLE
Added IP2Location.Open(byte[]) override

### DIFF
--- a/com/ip2location/IP2Location.java
+++ b/com/ip2location/IP2Location.java
@@ -97,6 +97,7 @@ public class IP2Location {
      * Sets the path for the license key file.
      */
     public String IPLicensePath = "";
+    private FileLike.Supplier binFile;
     private int COUNTRY_POSITION_OFFSET;
     private int REGION_POSITION_OFFSET;
     private int CITY_POSITION_OFFSET;
@@ -144,6 +145,19 @@ public class IP2Location {
 
     }
 
+    interface FileLike {
+
+        interface Supplier {
+            FileLike open() throws IOException;
+            boolean isValid();
+        }
+
+        int read(byte[] buffer) throws IOException;
+        int read(byte b[], int off, int len) throws IOException;
+        void seek(long pos) throws IOException;
+        void close() throws IOException;
+    }
+
     /**
      * This function can be used to pre-load the BIN file.
      *
@@ -152,6 +166,34 @@ public class IP2Location {
      */
     public void Open(String DBPath) throws IOException {
         IPDatabasePath = DBPath;
+        binFile = new FileLike.Supplier() {
+            public FileLike open() throws IOException {
+                return new FileLike() {
+                    private final RandomAccessFile aFile = new RandomAccessFile(DBPath, "r");
+
+                    public int read(byte[] buffer) throws IOException {
+                        return aFile.read(buffer);
+                    }
+
+                    public int read(byte[] b, int off, int len) throws IOException {
+                        return aFile.read(b, off, len);
+                    }
+
+                    public void seek(long pos) throws IOException {
+                        aFile.seek(pos);
+                    }
+
+                    public void close() throws IOException {
+                        aFile.close();
+                    }
+                };
+            }
+
+            public boolean isValid() {
+                return DBPath.length() > 0;
+            }
+        };
+
         LoadBIN();
     }
 
@@ -165,6 +207,38 @@ public class IP2Location {
     public void Open(String DBPath, boolean UseMMF) throws IOException {
         UseMemoryMappedFile = UseMMF;
         Open(DBPath);
+    }
+
+    public void Open(byte[] db) throws IOException {
+        binFile = new FileLike.Supplier() {
+            public FileLike open() {
+                return new FileLike() {
+                    private final ByteArrayInputStream stream = new ByteArrayInputStream(db);
+
+                    public int read(byte[] buffer) throws IOException {
+                        return stream.read(buffer);
+                    }
+
+                    public int read(byte[] b, int off, int len) {
+                        return stream.read(b, off, len);
+                    }
+
+                    public void seek(long pos) {
+                        stream.reset();
+                        stream.skip(pos);
+                    }
+
+                    public void close() throws IOException {
+                        stream.close();
+                    }
+                };
+            }
+
+            public boolean isValid() {
+                return db.length > 0;
+            }
+        };
+        LoadBIN();
     }
 
     /**
@@ -213,11 +287,11 @@ public class IP2Location {
 
     private boolean LoadBIN() throws IOException {
         boolean loadOK = false;
-        RandomAccessFile aFile = null;
+        FileLike aFile = null;
 
         try {
-            if (IPDatabasePath.length() > 0) {
-                aFile = new RandomAccessFile(IPDatabasePath, "r");
+            if (binFile.isValid()) {
+                aFile = binFile.open();
                 byte[] _HeaderData = new byte[64];
                 aFile.read(_HeaderData);
                 ByteBuffer _HeaderBuffer = ByteBuffer.wrap(_HeaderData);
@@ -372,7 +446,7 @@ public class IP2Location {
     public IPResult IPQuery(String IPAddress) throws IOException {
         IPAddress = IPAddress.trim();
         IPResult record = new IPResult(IPAddress);
-        RandomAccessFile filehandle = null;
+        FileLike filehandle = null;
         ByteBuffer mybuffer = null;
         ByteBuffer mydatabuffer = null;
         byte[] row;
@@ -435,7 +509,7 @@ public class IP2Location {
                 }
             } else {
                 DestroyMappedBytes();
-                filehandle = new RandomAccessFile(IPDatabasePath, "r");
+                filehandle = binFile.open();
             }
 
             if (myiptype == 4) { // IPv4
@@ -886,7 +960,7 @@ public class IP2Location {
         }
     }
 
-    private byte[] readRow(final long position, final long mylen, final ByteBuffer mybuffer, final RandomAccessFile filehandle) throws IOException {
+    private byte[] readRow(final long position, final long mylen, final ByteBuffer mybuffer, final FileLike filehandle) throws IOException {
         byte[] row = new byte[(int) mylen];
         if (UseMemoryMappedFile) {
             mybuffer.position((int) position);
@@ -905,7 +979,7 @@ public class IP2Location {
         return new BigInteger(1, buf);
     }
 
-    private BigInteger read32or128(final long position, final int myiptype, final ByteBuffer mybuffer, final RandomAccessFile filehandle) throws IOException {
+    private BigInteger read32or128(final long position, final int myiptype, final ByteBuffer mybuffer, final FileLike filehandle) throws IOException {
         if (myiptype == 4) {
             return read32(position, mybuffer, filehandle);
         } else if (myiptype == 6) {
@@ -914,7 +988,7 @@ public class IP2Location {
         return BigInteger.ZERO;
     }
 
-    private BigInteger read128(final long position, final ByteBuffer mybuffer, final RandomAccessFile filehandle) throws IOException {
+    private BigInteger read128(final long position, final ByteBuffer mybuffer, final FileLike filehandle) throws IOException {
         BigInteger retval;
         final int bsize = 16;
         byte[] buf = new byte[bsize];
@@ -939,7 +1013,7 @@ public class IP2Location {
         return new BigInteger(1, buf);
     }
 
-    private BigInteger read32(final long position, final ByteBuffer mybuffer, final RandomAccessFile filehandle) throws IOException {
+    private BigInteger read32(final long position, final ByteBuffer mybuffer, final FileLike filehandle) throws IOException {
         if (UseMemoryMappedFile) {
             // simulate unsigned int by using long
             return BigInteger.valueOf(mybuffer.getInt((int) position) & 0xffffffffL); // use absolute offset to be thread-safe
@@ -953,7 +1027,7 @@ public class IP2Location {
         }
     }
 
-    private String readStr(long position, final ByteBuffer mydatabuffer, final RandomAccessFile filehandle) throws IOException {
+    private String readStr(long position, final ByteBuffer mydatabuffer, final FileLike filehandle) throws IOException {
         int size = 256; // max size of string field + 1 byte for the length
         final int len;
         final byte[] data = new byte[size];

--- a/test/java/IP2LocationTest.java
+++ b/test/java/IP2LocationTest.java
@@ -15,12 +15,15 @@ class IP2LocationTest {
     private static IP2Location loc;
     private static String binfile = "IP2LOCATION-LITE-DB1.BIN";
     private static String binfilepath;
+    private static byte[] binFileBytes;
+
     private static String ip = "8.8.8.8";
 
     @BeforeAll
-    static void Setup() {
+    static void Setup() throws IOException {
         Path binpath = Paths.get("src", "test", "resources", binfile);
         binfilepath = binpath.toFile().getAbsolutePath();
+        binFileBytes = Files.readAllBytes(binpath);
     }
 
     @BeforeEach
@@ -32,6 +35,10 @@ class IP2LocationTest {
     void TestOpenException() {
         assertThrows(IOException.class, () -> {
             loc.Open("dummy.bin");
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            loc.Open((byte[])null);
         });
     }
 


### PR DESCRIPTION
IP2Location.Open(byte[]) allows the use of a byte array without requiring an actual file. This is useful when:

- memory is not a concern and performance is preferred. The array can be simply returned by Files.readAllBytes(path)
- when the byte[] is submitted over network for a cluster of workers such in an EMR job using spark broadcast
