### PR TITLE
Expose MetaData as part of public API.

### DIFF
--- a/com/ip2location/IP2Location.java
+++ b/com/ip2location/IP2Location.java
@@ -770,6 +770,10 @@ public class IP2Location {
         }
     }
 
+    public MetaData MetaData() {
+        return _MetaData;
+    }
+
     private String[] expandIPV6(final String myIP, final int myiptype) {
         final String tmp = "0000:0000:0000:0000:0000:";
         final String padme = "0000";

--- a/com/ip2location/MetaData.java
+++ b/com/ip2location/MetaData.java
@@ -1,7 +1,6 @@
 package com.ip2location;
 
-// package-private access
-class MetaData {
+public class MetaData {
     private int _BaseAddr = 0;
     private int _DBCount = 0;
     private int _DBColumn = 0;
@@ -24,16 +23,15 @@ class MetaData {
 
     }
 
-    // all package-private access
     int getBaseAddr() {
         return _BaseAddr;
     }
 
-    int getDBCount() {
+    public int getDBCount() {
         return _DBCount;
     }
 
-    int getDBColumn() {
+    public int getDBColumn() {
         return _DBColumn;
     }
 
@@ -41,15 +39,15 @@ class MetaData {
         return _DBType;
     }
 
-    int getDBDay() {
+    public int getDBDay() {
         return _DBDay;
     }
 
-    int getDBMonth() {
+    public int getDBMonth() {
         return _DBMonth;
     }
 
-    int getDBYear() {
+    public int getDBYear() {
         return _DBYear;
     }
 
@@ -89,7 +87,7 @@ class MetaData {
         return _ProductType;
     }
 
-    int getFileSize() {
+    public int getFileSize() {
         return _FileSize;
     }
 

--- a/test/java/IP2LocationTest.java
+++ b/test/java/IP2LocationTest.java
@@ -217,6 +217,18 @@ class IP2LocationTest {
         assertEquals(rec.getAS(), "Not_Supported");
     }
 
+    @Test
+    void TestMetaData() throws IOException {
+        loc.Open(binfilepath);
+        MetaData metaData = loc.MetaData();
+        assertEquals(14, metaData.getDBDay());
+        assertEquals(3, metaData.getDBMonth());
+        assertEquals(21, metaData.getDBYear());
+        assertEquals(195811, metaData.getDBCount());
+        assertEquals(2, metaData.getDBColumn());
+        assertEquals(2094492, metaData.getFileSize());
+    }
+
     @AfterEach
     void TearDown() {
         loc.Close();


### PR DESCRIPTION
Useful for getting the date and size of the database.

My use case is doing automated ip2loc database update process. It is helpful to have access to database date to make sure the correct version is being used.