### PR TITLE
Avoid NullPointerException for trim IPAddress

### DIFF
--- a/com/ip2location/IP2Location.java
+++ b/com/ip2location/IP2Location.java
@@ -500,7 +500,9 @@ public class IP2Location {
      * @throws IOException If an input or output exception occurred
      */
     public IPResult IPQuery(String IPAddress) throws IOException {
-        IPAddress = IPAddress.trim();
+        if (IPAddress != null) {
+            IPAddress = IPAddress.trim();    
+        }
         IPResult record = new IPResult(IPAddress);
         FileLike filehandle = null;
         ByteBuffer mybuffer = null;


### PR DESCRIPTION
Avoid NullPointerException for trim IPAddress, and make sure for null or blank string return same IPResult with status EMPTY_IP_ADDRESS